### PR TITLE
Stop rewriting same PlayStore RPC data to cache

### DIFF
--- a/lib/candy_check/play_store.rb
+++ b/lib/candy_check/play_store.rb
@@ -1,6 +1,7 @@
 require 'google/api_client'
 
 require 'candy_check/play_store/discovery_repository'
+require 'candy_check/play_store/discovery_api'
 require 'candy_check/play_store/client'
 require 'candy_check/play_store/config'
 require 'candy_check/play_store/receipt'

--- a/lib/candy_check/play_store/discovery_api.rb
+++ b/lib/candy_check/play_store/discovery_api.rb
@@ -1,0 +1,55 @@
+module CandyCheck
+  module PlayStore
+    # Abstract knowledge about Discovery Repositories and when to read or write
+    # to them.
+    class DiscoveryApi
+      # Error thrown if the discovery of the API wasn't successful
+      class Error < RuntimeError; end
+
+      # API discovery namespace
+      API_DISCOVER = 'androidpublisher'.freeze
+      # API version
+      API_VERSION  = 'v2'.freeze
+
+      # Create a new instance with the cache repository
+      # @param attributes [Hash]
+      def initialize(attributes)
+        @repository = attributes.fetch(:repository)
+      end
+
+      def rpc(api_client:)
+        rpc = load_discover_dump
+        return rpc if rpc
+
+        rpc = request_discover(api_client)
+        validate_rpc!(rpc)
+        write_discover_dump(rpc)
+
+        rpc
+      end
+
+      private
+
+      attr_reader :repository
+
+      def request_discover(api_client)
+        api_client.discovered_api(API_DISCOVER, API_VERSION)
+      end
+
+      def validate_rpc!(rpc)
+        return if rpc.purchases.products.get
+        raise Error, 'Unable to get the API discovery'
+      rescue NoMethodError
+        raise Error, 'Unable to get the API discovery'
+      end
+
+      def load_discover_dump
+        repository.load
+      end
+
+      def write_discover_dump(rpc)
+        repository.save(rpc)
+      end
+    end
+  end
+end

--- a/spec/play_store/discovery_api_spec.rb
+++ b/spec/play_store/discovery_api_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe CandyCheck::PlayStore::Client do
+  include WithTempFile
+  include WithFixtures
+
+  with_temp_file :cache_file
+
+  subject do
+    CandyCheck::PlayStore::DiscoveryApi.new(
+      repository: repository
+    )
+  end
+  let(:repository) { MiniTest::Mock.new }
+  let(:api_client) { MiniTest::Mock.new }
+  let(:rpc_fake_valid) do
+    OpenStruct.new(
+      purchases: OpenStruct.new(
+        products: OpenStruct.new(
+          get: true
+        )
+      )
+    )
+  end
+  let(:rpc_fake_invalid) do
+    OpenStruct.new(broken: true)
+  end
+
+  describe 'rpc' do
+    describe 'w/o cache file' do
+      it 'writes to cache and returns rpc' do
+        api_client.expect(
+          :discovered_api, rpc_fake_valid, %w(androidpublisher v2)
+        )
+        repository.expect(:load, nil)
+        repository.expect(:save, nil, [rpc_fake_valid])
+
+        rpc = subject.rpc(api_client: api_client)
+
+        assert_equal rpc, rpc_fake_valid
+        assert_mock repository
+        assert_mock api_client
+      end
+
+      it 'fails rpc validation' do
+        api_client.expect(
+          :discovered_api, rpc_fake_invalid, %w(androidpublisher v2)
+        )
+        repository.expect(:load, nil)
+
+        proc { subject.rpc(api_client: api_client) }.must_raise \
+          CandyCheck::PlayStore::DiscoveryApi::Error
+
+        assert_mock repository
+        assert_mock api_client
+      end
+    end
+
+    describe 'with cache file' do
+      let(:cache_file_path) { fixture_path('play_store', 'api_cache.dump') }
+
+      it 'loads the discovery from cache file' do
+        repository.expect(:load, rpc_fake_valid)
+
+        rpc = subject.rpc(api_client: api_client)
+
+        assert_equal rpc, rpc_fake_valid
+        assert_mock repository
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously the code would load from cache and then rewrite the same data
to cache. This is a problem for concurrency because reading/writing from
a file will break when another process is doing the same thing.

This adds a new class, DiscoveryAPI, to coordinate access to the cache
file and it reduces collisions by only writing to the cache when there
isn't a file.